### PR TITLE
Missing brackets were making my blog to go by the name of swechha jha

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -192,6 +192,5 @@ name = Abdul Raheem (ABD)
 [https://BhaveshSGupta.me/index.xml]
 name = Bhavesh Gupta (BhaveshSGupta)
 
-https://sweksha285784158.wordpress.com/
+[https://sweksha285784158.wordpress.com/]
 name = swechha jha (sweksha)
-

--- a/planet.ini
+++ b/planet.ini
@@ -192,5 +192,5 @@ name = Abdul Raheem (ABD)
 [https://BhaveshSGupta.me/index.xml]
 name = Bhavesh Gupta (BhaveshSGupta)
 
-[https://sweksha285784158.wordpress.com/]
+[https://sweksha285784158.wordpress.com/feed]
 name = swechha jha (sweksha)


### PR DESCRIPTION
On student planets my blog was going by the name of swechha jha's blog probably because of missing brackets.  Also removed a extra blank line.